### PR TITLE
Should stop it crashing on linux not tested on windows.

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,0 +1,15 @@
+// cSpell Settings
+{
+    // Version of the setting file.  Always 0.1
+    "version": "0.1",
+    // language - current active spelling language
+    "language": "en",
+    // words - list of words to be always considered correct
+    "words": [],
+    // flagWords - list of words to be always considered incorrect
+    // This is useful for offensive words and common spelling errors.
+    // For example "hte" should be "the"
+    "flagWords": [
+        "hte"
+    ]
+}

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -5,7 +5,10 @@
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct
-    "words": [],
+    "words": [
+        "concat",
+        "popen"
+    ],
     // flagWords - list of words to be always considered incorrect
     // This is useful for offensive words and common spelling errors.
     // For example "hte" should be "the"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "cSpell.enabled": true,
+    "cSpell.enabledLanguageIds": [
+        "c",
+        "cpp",
+        "csharp",
+        "go",
+        "javascript",
+        "javascriptreact",
+        "json",
+        "latex",
+        "lua",
+        "markdown",
+        "php",
+        "plaintext",
+        "python",
+        "text",
+        "typescript",
+        "typescriptreact",
+        "yml"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Please use the issue tracker to fill issues or feature requests!
 
 * Limited Windows support (also; can only read files from `C:`)
 
+* Version 2 not backwards compatible, only works on Micro Editor version 1.3.2 and above.

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -1,7 +1,7 @@
-VERSION = "1.3.4"
+VERSION = "1.4.0"
 
 treeView = nil
-cwd = DirectoryName(".")
+cwd = WorkingDirectory()
 driveLetter = "C:\\"
 isWin = (OS == "windows")
 debug = true
@@ -167,7 +167,7 @@ function preQuitAll(view) treeView.Buf.IsModified = false end
 function scanDir(directory)
     if debug == true then messenger:AddLog("***** scanDir(directory) ---> ",directory) end
     local i, list, proc = 3, {}, nil
-    list[1] = (isWin and driveLetter or "") .. cwd  -- TODO: get current directory working.
+    list[1] = (isWin and driveLetter or "") .. cwd  -- current directory working.
     list[2] = ".."  -- used for going up a level in directory.
     if isWin then  -- if windows
         proc = io.popen('dir /a /b "'..directory..'"')
@@ -201,11 +201,6 @@ function isDir(path)
     return dir
 end
 
-function Test()
-    messenger:Error("Current Directory -->",WorkingDirectory())
-end
-
--- micro editor 
+-- micro editor commands
 MakeCommand("tree", "filemanager.ToggleTree", 0)
-MakeCommand("treet","filemanager.Test",0)
 AddRuntimeFile("filemanager", "syntax", "syntax.yaml")

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -4,7 +4,7 @@ treeView = nil
 cwd = WorkingDirectory()
 driveLetter = "C:\\"
 isWin = (OS == "windows")
-debug = true
+debug = false
 
 -- ToggleTree will toggle the tree view visible (create) and hide (delete).
 function ToggleTree()

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -12,21 +12,23 @@ function OpenTree()
     treeView = CurView()
     treeView.Width = 30
     treeView.LockWidth = true
-    SetLocalOption("ruler", "false", treeView)
-    SetLocalOption("softwrap", "true", treeView)
-    SetLocalOption("autosave", "false", treeView)
-    SetLocalOption("statusline", "false", treeView)
-    SetLocalOption("readonly", "true", treeView)
-    SetLocalOption("kind",2,treeView)
+    -- set options for tree view
+    status = SetLocalOption("ruler", "false", treeView)
+    if status ~= nil then messenger:Error("ruler -> ",status) end
+    status = SetLocalOption("softwrap", "true", treeView)
+    if status ~= nil then messenger:Error("softwrap -> ",status) end
+    status = SetLocalOption("autosave", "false", treeView)
+    if status ~= nil then messenger:Error("autosave -> ", status)  end
+    status = SetLocalOption("statusline", "false", treeView)
+    if status ~= nil then messenger:Error("statusline -> ",status) end
     tabs[curTab+1]:Resize()
-    if debug == true then messenger:Error("test") end
     refreshTree()
 end
 
 -- mouse callback from micro editor when a left button is clicked on your view
 function onMousePress(view, event)
-    local colunms, rows = event:Position()
-    if debug == true then messenger:Error("coloumns location rows location ",colunms,rows) end
+    local columns, rows = event:Position()
+    if debug == true then messenger:Error("coloumns location rows location ",columns,rows) end
 end
 
 -- CloseTree will close the tree plugin view and release memory.

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -18,6 +18,12 @@ end
 -- OpenTree setup's the view
 function OpenTree()
     CurView():VSplitIndex(NewBuffer("", ""), 0)
+    setupOptions()
+    refreshTree()
+end
+
+-- setupOptions setup tree view options
+function setupOptions()
     treeView = CurView()
     treeView.Width = 30
     treeView.LockWidth = true
@@ -31,7 +37,6 @@ function OpenTree()
     status = SetLocalOption("statusline", "false", treeView)
     if status ~= nil then messenger:Error("statusline -> ",status) end
     tabs[curTab+1]:Resize()
-    refreshTree()
 end
 
 -- mouse callback from micro editor when a left button is clicked on your view

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -37,7 +37,7 @@ end
 -- mouse callback from micro editor when a left button is clicked on your view
 function onMousePress(view, event)
     local columns, rows = event:Position()
-    if debug == true then messenger:Error("coloumns location rows location ",columns,rows) end
+    if debug == true then messenger:Error("columns location rows location ",columns,rows) end
 end
 
 -- CloseTree will close the tree plugin view and release memory.

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -1,4 +1,4 @@
-VERSION = "1.4.0"
+VERSION = "2.0.0"
 
 treeView = nil
 cwd = WorkingDirectory()

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -17,7 +17,7 @@ end
 
 -- OpenTree setup's the view
 function OpenTree()
-    CurView():VSplitIndex(NewBuffer("", ""), 0)
+    CurView():VSplitIndex(NewBuffer("", "FileManager"), 0)
     setupOptions()
     refreshTree()
 end

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -8,7 +8,7 @@ debug = true
 
 -- ToggleTree will toggle the tree view visible (create) and hide (delete).
 function ToggleTree()
-    if debug == true then messenger:AddLog("<--- ToggleTree()  --->") end
+    if debug == true then messenger:AddLog("***** ToggleTree() *****") end
     if treeView == nil then
         OpenTree()
     else
@@ -18,7 +18,7 @@ end
 
 -- OpenTree setup's the view
 function OpenTree()
-    if debug == true then messenger:AddLog("<--- OpenTree()  --->") end
+    if debug == true then messenger:AddLog("***** OpenTree() *****") end
     CurView():VSplitIndex(NewBuffer("", "FileManager"), 0)
     setupOptions()
     refreshTree()
@@ -26,7 +26,7 @@ end
 
 -- setupOptions setup tree view options
 function setupOptions()
-    if debug == true then messenger:AddLog("<--- setupOptions()  --->") end
+    if debug == true then messenger:AddLog("***** setupOptions() *****") end
     treeView = CurView()
     treeView.Width = 30
     treeView.LockWidth = true
@@ -48,13 +48,13 @@ end
 function onMousePress(view, event)
     if view == treeView then  -- check view is tree as only want inputs from that view.
          local columns, rows = event:Position()
-         if debug == true then messenger:AddLog("Mouse pressed -> columns location rows location -> ",columns,rows) end
+         if debug == true then messenger:AddLog("INFO: --> Mouse pressed -> columns location rows location -> ",columns,rows) end
     end
 end
 
 -- CloseTree will close the tree plugin view and release memory.
 function CloseTree()
-    if debug == true then messenger:AddLog("<--- CloseTree()  --->") end
+    if debug == true then messenger:AddLog("***** CloseTree() *****") end
     if treeView ~= nil then
         treeView.Buf.IsModified = false
         treeView:Quit(false)
@@ -66,21 +66,21 @@ end
 
 -- refreshTree will remove the buffer and load contents from folder
 function refreshTree()
-    if debug == true then messenger:AddLog("<--- refreshTree()  --->") end
+    if debug == true then messenger:AddLog("***** refreshTree() *****") end
     treeView.Buf:remove(treeView.Buf:Start(), treeView.Buf:End())
     treeView.Buf:Insert(Loc(0,0), table.concat(scanDir(cwd), "\n "))
 end
 
 -- returns currently selected line in treeView
 function getSelection()
-    if debug == true then messenger:AddLog("<--- getSelection()  --->") end
+    if debug == true then messenger:AddLog("***** getSelection() *****") end
     return (treeView.Buf:Line(treeView.Cursor.Loc.Y)):sub(2)
 end
 
 -- When user presses enter then if it is a folder clear buffer and reload contents with folder selected.
 -- If it is a file then open it in a new vertical view
 function preInsertNewline(view)
-    if debug == true then messenger:AddLog("<--- preInsertNewLine(view) %v --->",view) end
+    if debug == true then messenger:AddLog("***** preInsertNewLine(view)  ---> ",view) end
     if view == treeView then
         local selected = getSelection()
         if view.Cursor.Loc.Y == 0 then
@@ -102,7 +102,7 @@ end
 
 -- disallow selecting topmost line in treeView:
 function preCursorUp(view) 
-    if debug == true then messenger:AddLog("<--- preCursor(view)  %v  --->",view) end
+    if debug == true then messenger:AddLog("***** preCursor(view)  ---> ",view) end
     if view == treeView then
         if view.Cursor.Loc.Y == 1 then
             return false
@@ -110,7 +110,7 @@ end end end
 
 -- don't use built-in view.Cursor:SelectLine() as it will copy to clipboard (in old versions of Micro)
 function selectLineInTree(view)
-    if debug == true then messenger:AddLog("<--- selectLineInTree(v) %v  --->",view) end
+    if debug == true then messenger:AddLog("***** selectLineInTree(v)  ---> ",view) end
     if view == treeView then
         local y = view.Cursor.Loc.Y
         view.Cursor.CurSelection[1] = Loc(0, y)
@@ -124,7 +124,7 @@ function onCursorUp(view)   selectLineInTree(view) end
 
 -- allows for deleting files
 function preDelete(view)
-    if debug == true then messenger:AddLog("<--- preDelete(view) %v  --->",view) end
+    if debug == true then messenger:AddLog("***** preDelete(view)  ---> ",view) end
     if view == treeView then
         local selected = getSelection()
         if selected == ".." then return false end
@@ -152,7 +152,7 @@ end
 
 -- don't prompt to save tree view
 function preQuit(view)
-    if debug == true then messenger:AddLog("<--- preQuit(view) %v  --->",view) end
+    if debug == true then messenger:AddLog("***** preQuit(view) ---> ",view) end
     if view == treeView then
         view.Buf.IsModified = false
     end
@@ -161,7 +161,7 @@ function preQuitAll(view) treeView.Buf.IsModified = false end
 
 -- scanDir will scan contents of the directory passed.
 function scanDir(directory)
-    if debug == true then messenger:AddLog("<--- scanDir(directory) %v  --->",directory) end
+    if debug == true then messenger:AddLog("***** scanDir(directory) ---> ",directory) end
     local i, list, proc = 3, {}, nil
     list[1] = (isWin and driveLetter or "") .. cwd  -- TODO: get current directory working.
     list[2] = ".."  -- used for going up a level in directory.
@@ -182,7 +182,7 @@ end
 -- isDir checks if the path passed is a directory.
 -- return true if it is a directory else false if it is not a directory.
 function isDir(path)
-    if debug == true then messenger:AddLog("<--- isDir(path) %v  --->",path) end
+    if debug == true then messenger:AddLog("***** isDir(path) ---> ",path) end
     local dir, proc = false, nil
     if isWin then
         proc = io.popen('IF EXIST ' .. driveLetter .. JoinPaths(cwd, path) .. '/* (ECHO d) ELSE (ECHO -)')

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -4,10 +4,11 @@ treeView = nil
 cwd = DirectoryName(".")
 driveLetter = "C:\\"
 isWin = (OS == "windows")
-debug = false
+debug = true
 
 -- ToggleTree will toggle the tree view visible (create) and hide (delete).
 function ToggleTree()
+    if debug == true then messenger:AddLog("<--- ToggleTree()  --->") end
     if treeView == nil then
         OpenTree()
     else
@@ -17,6 +18,7 @@ end
 
 -- OpenTree setup's the view
 function OpenTree()
+    if debug == true then messenger:AddLog("<--- OpenTree()  --->") end
     CurView():VSplitIndex(NewBuffer("", "FileManager"), 0)
     setupOptions()
     refreshTree()
@@ -24,29 +26,32 @@ end
 
 -- setupOptions setup tree view options
 function setupOptions()
+    if debug == true then messenger:AddLog("<--- setupOptions()  --->") end
     treeView = CurView()
     treeView.Width = 30
     treeView.LockWidth = true
     -- set options for tree view
     status = SetLocalOption("ruler", "false", treeView)
-    if status ~= nil then messenger:Error("ruler -> ",status) end
+    if status ~= nil then messenger:AddLog("ruler -> ",status) end
     status = SetLocalOption("softwrap", "true", treeView)
-    if status ~= nil then messenger:Error("softwrap -> ",status) end
+    if status ~= nil then messenger:AddLog("softwrap -> ",status) end
     status = SetLocalOption("autosave", "false", treeView)
-    if status ~= nil then messenger:Error("autosave -> ", status)  end
+    if status ~= nil then messenger:AddLog("autosave -> ", status)  end
     status = SetLocalOption("statusline", "false", treeView)
-    if status ~= nil then messenger:Error("statusline -> ",status) end
+    if status ~= nil then messenger:AddLog("statusline -> ",status) end
+    messenger:Error("Error -> ",treeView.Type)
     tabs[curTab+1]:Resize()
 end
 
 -- mouse callback from micro editor when a left button is clicked on your view
 function onMousePress(view, event)
     local columns, rows = event:Position()
-    if debug == true then messenger:Error("columns location rows location ",columns,rows) end
+    if debug == true then messenger:AddLog("columns location rows location ",columns,rows) end
 end
 
 -- CloseTree will close the tree plugin view and release memory.
 function CloseTree()
+    if debug == true then messenger:AddLog("<--- CloseTree()  --->") end
     if treeView ~= nil then
         treeView.Buf.IsModified = false
         treeView:Quit(false)
@@ -58,18 +63,21 @@ end
 
 -- refreshTree will remove the buffer and load contents from folder
 function refreshTree()
+    if debug == true then messenger:AddLog("<--- refreshTree()  --->") end
     treeView.Buf:remove(treeView.Buf:Start(), treeView.Buf:End())
     treeView.Buf:Insert(Loc(0,0), table.concat(scanDir(cwd), "\n "))
 end
 
 -- returns currently selected line in treeView
 function getSelection()
+    if debug == true then messenger:AddLog("<--- getSelection()  --->") end
     return (treeView.Buf:Line(treeView.Cursor.Loc.Y)):sub(2)
 end
 
 -- When user presses enter then if it is a folder clear buffer and reload contents with folder selected.
 -- If it is a file then open it in a new vertical view
 function preInsertNewline(view)
+    if debug == true then messenger:AddLog("<--- preInsertNewLine(view) %v --->",view) end
     if view == treeView then
         local selected = getSelection()
         if view.Cursor.Loc.Y == 0 then
@@ -91,6 +99,7 @@ end
 
 -- disallow selecting topmost line in treeView:
 function preCursorUp(view) 
+    if debug == true then messenger:AddLog("<--- preCursor(view)  %v  --->",view) end
     if view == treeView then
         if view.Cursor.Loc.Y == 1 then
             return false
@@ -98,6 +107,7 @@ end end end
 
 -- don't use built-in view.Cursor:SelectLine() as it will copy to clipboard (in old versions of Micro)
 function selectLineInTree(v)
+    if debug == true then messenger:AddLog("<--- selectLineInTree(v) %v  --->",v) end
     if v == treeView then
         local y = v.Cursor.Loc.Y
         v.Cursor.CurSelection[1] = Loc(0, y)
@@ -111,6 +121,7 @@ function onCursorUp(view)   selectLineInTree(view) end
 
 -- allows for deleting files
 function preDelete(view)
+    if debug == true then messenger:AddLog("<--- preDelete(view) %v  --->",view) end
     if view == treeView then
         local selected = getSelection()
         if selected == ".." then return false end
@@ -138,6 +149,7 @@ end
 
 -- don't prompt to save tree view
 function preQuit(view)
+    if debug == true then messenger:AddLog("<--- preQuit(view) %v  --->",view) end
     if view == treeView then
         view.Buf.IsModified = false
     end
@@ -146,6 +158,7 @@ function preQuitAll(view) treeView.Buf.IsModified = false end
 
 -- scanDir will scan contents of the directory passed.
 function scanDir(directory)
+    if debug == true then messenger:AddLog("<--- scanDir(directory) %v  --->",directory) end
     local i, t, proc = 3, {}, nil
     t[1] = (isWin and driveLetter or "") .. cwd
     t[2] = ".."
@@ -165,6 +178,7 @@ end
 -- isDir checks if the path passed is a directory.
 -- return true if it is a directory else false if it is not a directory.
 function isDir(path)
+    if debug == true then messenger:AddLog("<--- isDir(path) %v  --->",path) end
     local dir, proc = false, nil
     if isWin then
         proc = io.popen('IF EXIST ' .. driveLetter .. JoinPaths(cwd, path) .. '/* (ECHO d) ELSE (ECHO -)')

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -6,6 +6,15 @@ driveLetter = "C:\\"
 isWin = (OS == "windows")
 debug = false
 
+-- ToggleTree will toggle the tree view visible (create) and hide (delete).
+function ToggleTree()
+    if treeView == nil then
+        OpenTree()
+    else
+        CloseTree()
+    end
+end
+
 -- OpenTree setup's the view
 function OpenTree()
     CurView():VSplitIndex(NewBuffer("", ""), 0)
@@ -40,14 +49,7 @@ function CloseTree()
     end
 end
 
--- ToggleTree will toggle the view visable and hidden.
-function ToggleTree()
-    if treeView == nil then
-        OpenTree()
-    else
-        CloseTree()
-    end
-end
+
 
 -- refreshTree will remove the buffer and load contents from folder
 function refreshTree()

--- a/repo.json
+++ b/repo.json
@@ -4,10 +4,10 @@
   "Tags": ["filetree", "filemanager", "file", "manager"],
   "Versions": [
     {
-      "Version": "1.3.4",
+      "Version": "1.4.0",
       "Url": "https://github.com/NicolaiSoeborg/filemanager-plugin/archive/v1.3.4.zip",
       "Require": {
-        "micro": ">=1.1.5"
+        "micro": ">=1.3.2"
       }
     }
   ]


### PR DESCRIPTION
## Warning
I have moved your code around a lot, put debug info in it. Changed to version 2 as only works with version 1.3.2 nightly branch.
`You could look at the code and just take the parts needed to stop it crashing.`

## Patch
It stops crashing on linux as the current working directory is not supported in micro editor until version 1.3.2 nightly branch.

## Only works with micro ediotor 1.3.2 nightly branch.
Note: Debug mode is off by default but can be put on by changeing debug variable to true in the lua code.

# Not tested on windows.
## backwards
To make backwards with micro editor you could use linux command to get the current working directory, as it is used for geting directory list. (os.execute(command))
