### PR TITLE
Add proper way to install plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A simple plugin that allows for easy navigation of a file tree.
 
-Place this folder in `~/.config/micro/plugins/` and restart micro:
-> git clone https://github.com/NicolaiSoeborg/filemanager-plugin.git ~/.config/micro/plugins/filemanager
+To install, simply run `plugin install filemanager` and restart Micro.
 
 Now it will be possible to open a navigation panel by running 
 the command `tree` (<kbd>Ctrl</kbd> + <kbd>E</kbd>) or creating


### PR DESCRIPTION
By adding the repo to `pluginrepos`, the user can use `plugin install filemanager` and `plugin update` to install/update your plugin. 