### PR TITLE
Fix Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,4 @@ Please use the issue tracker to fill issues or feature requests!
 
 ### Known Issues
 
-* Limited Windows support (also; can only read files from `C:`)
-
 * Version 2 not backwards compatible, only works on Micro Editor version 1.3.2 and above.


### PR DESCRIPTION
While untested on Windows, I see no reason why it shouldn't work.

Note that you can also use the `path_root` function to get the root `/` on non-Windows (which I did test 😄 )

Unrelated: Might I consider formatting your code with [lua-fmt](https://github.com/trixnz/lua-fmt)? My [fmt plugin](https://github.com/sum01/fmt-micro) <sup>shameless promotion</sup> supports it 👍 