### PR TITLE
Use Go's standard libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,4 @@ Please use the issue tracker to fill issues or feature requests!
 
 ### Known Issues
 
-* Limited Windows support (also; can only read files from `C:`)
-
 * Version 2 not backwards compatible, only works on Micro Editor version 1.3.2 and above.


### PR DESCRIPTION
Fixes Windows support, and makes the plugin more portable since it isn't using `io.popen` now.

Tesed on both Linux & Windows.

This could possibly fix #2 but I haven't personally tested on Android.