### PR TITLE
[WIP] Fixes and more

### DIFF
--- a/filemanager.lua
+++ b/filemanager.lua
@@ -167,7 +167,7 @@ end
 function preCursorUp(view)  
     if view == treeView then
         debug("***** preCursor() *****")
-        if view.Cursor.Loc.Y == 1 then
+        if treeView.Buf.Cursor.Loc.Y == 1 then
             return false
 end end end
 
@@ -200,14 +200,13 @@ function preDelete(view)
     end
 end
 
-
 -- When user presses enter then if it is a folder clear buffer and reload contents with folder selected.
 -- If it is a file then open it in a new vertical view
 function preInsertNewline(view)
     if view == treeView then
         debug("***** preInsertNewLine()  *****")
         local selected = getSelection()
-        if view.Cursor.Loc.Y == 0 then
+        if treeView.Buf.Cursor.Loc.Y == 0 then
             return false -- topmost line is cwd, so disallowing selecting it
         elseif isDir(selected) then  -- if directory then reload contents of tree view
             cwd = JoinPaths(cwd, selected)
@@ -215,7 +214,7 @@ function preInsertNewline(view)
         else  -- open file in new vertical view
             local filename = JoinPaths(cwd, selected)
             CurView():VSplitIndex(NewBuffer("", filename), 1)
-            CurView():ReOpen()
+            CurView().Buf:ReOpen()
             tabs[curTab+1]:Resize()
         end
         return false

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -42,6 +42,8 @@ function setupOptions()
     if status ~= nil then messenger:Error("Error setting autosave option -> ", status)  end
     status = SetLocalOption("statusline", "false", treeView)
     if status ~= nil then messenger:Error("Error setting statusline option -> ",status) end
+    status = SetLocalOption("scrollbar", "false", treeView)
+    if status ~= nil then messenger:Error("Error setting scrollbar option -> ",status) end
     -- TODO: need to set readonly in view type.
     tabs[curTab+1]:Resize()
 end

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -102,6 +102,18 @@ function onCursorUp(view)
   end
 end
 
+function preParagraphPrevious(view)
+  if view == treeView then
+    return false
+  end
+end
+
+function preParagraphNext(view)
+  if view == treeView then
+    return false
+  end
+end
+
 -- Moves the cursor to the ".." in treeView
 local function move_cursor_top()
     -- -1 is to not go past the ".." in the buffer


### PR DESCRIPTION
Do not merge yet, there is a weird bug where cursor down moves 2 indicies at a time.

---

What this brings:
* Fixes index out of range when opening very large folders
* Fixes the cursor/files/dirs/content/whatever being offscreen after opening something in a long list
* Fixes PageUp & Ctrl+Up to not go to invalid indicies (so not past the `..`)
* Adds a visual separator between the dir and `..` which looks like:
    ```
    dir
    ──────────
    ..
    files here
    ```
* Disables the new scrollbar feature on the tree
* Disables the new paragraph movement on the tree