### PR TITLE
Hide dotfiles and/or gitignored, changelog, and a bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 * A bug with the `rm` command that caused weird, undefined behaviour to contents within the same dir as the file/dir deleted.
+* Issue [#24](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/24)
 
 ## [3.0.0] - 2017-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* The ability to hide dotfiles using the `filemanager-showdotfiles` option.
+* The ability to hide files ignored in your VCS (aka `.gitignore`'d) using the `filemanager-showignored` option. Only works with Git at the moment.
+* This `CHANGELOG.md`
+
+### Fixed
+
+* A bug with the `rm` command that caused weird, undefined behaviour to contents within the same dir as the file/dir deleted.
+
+## [3.0.0] - 2017-01-10
+
+### Fixed
+
+* Issues [#13](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/13), [#14](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/14), [#15](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/15), [#19](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/19), [#20](https://github.com/NicolaiSoeborg/filemanager-plugin/issues/20)
+* The broken syntax highlighting
+
+### Added
+
+* Directory expansion/compression below itself for viewing more akin to a file tree.
+* The `rm` command, which deletes the file/directory under the cursor.
+* The `touch` command, which creates a file with the passed filename.
+* The `mkdir` command, which creates a directory with the passed filename.
+* An API, of sorts, for the user to rebind their keys to if they dislike the defaults.
+* An [editorconfig](http://editorconfig.org/) file.
+
+### Changed
+
+* The view that it spawns in to read-only, which requires Micro version >= 1.3.5
+* The functionality of some keybindings (when in the view) so they work safetly, or at all, with the plugin.
+* From the `enter` key to `tab` for opening/going into files/dirs (a side-effect of using the read-only setting)
+
+### Removed
+
+* The ability to use a lot of keybindings that would otherwise mess with the view, and have no benifit.
+* The pointless `.gitignore` file.
+
+[unreleased]: https://github.com/NicolaiSoeborg/filemanager-plugin/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/NicolaiSoeborg/filemanager-plugin/compare/v2.1.1...v3.0.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The `..` near the top is used to move back a directory, from your current positi
 All directories have a `/` added to the end of it, and are syntax-highlighted as a `special` character.\
 If it hasn't been uncompressed, there will be a `+` to the left of it. If it has been uncompressed, it will be a `-` instead.
 
+If you want to disable dotfiles from being shown, run `set filemanager-showdotfiles false` in Micro, then close & open the tree.\
+If you want to disable VCS-ignored (aka `.gitignore`) files from being shown, run `set filemanager-showignored false` in Micro, then close & open the tree.
+
 **NOTE:** If you change files without using the plugin, it can't know what you did. The only fix is to close and open the tree.
 
 ### Commands and Keybindings

--- a/README.md
+++ b/README.md
@@ -6,21 +6,13 @@ A simple plugin that allows for easy navigation of a file tree.
 
 **Installation:** run `plugin install filemanager` and restart Micro.
 
-# Table Of Content
-
-* [Basics](#basics)
-* [Commands and Keybindings](#commands-and-keybindings)
-* [Rebinding](#rebinding-things)
-* [In-depth](#commands-in-depth)
-
 ## Basics
 
-The top line always has the current directory's path to show you where you are.  
+The top line always has the current directory's path to show you where you are.\
 The `..` near the top is used to move back a directory, from your current position.
 
-All directories have a `/` added to the end of it, and are syntax-highlighted as a `special` character.  
-If it hasn't been uncompressed, there will be a `+` to the left of it.  
-If it has been uncompressed, there will be a `-` to the left of it.
+All directories have a `/` added to the end of it, and are syntax-highlighted as a `special` character.\
+If it hasn't been uncompressed, there will be a `+` to the left of it. If it has been uncompressed, it will be a `-` instead.
 
 **NOTE:** If you change files without using the plugin, it can't know what you did. The only fix is to close and open the tree.
 
@@ -28,50 +20,27 @@ If it has been uncompressed, there will be a `-` to the left of it.
 
 The keybindings below are the equivalent to Micro's defaults, and not actually set by the plugin. If you've changed any of those keybindings, then that key is used instead.
 
-| Command  | Keybinding(s)              | What it does                                                                                |
-| :------- | :------------------------- | :------------------------------------------------------------------------------------------ |
-| `tree`   | -                          | Open or close the tree                                                                      |
-| -        | <kbd>Tab</kbd> & MouseLeft | Open a file, or go into the directory. Goes back a dir if on `..`                           |
-| -        | <kbd>→</kbd>               | Uncompress a directory's content under it                                                   |
-| -        | <kbd>←</kbd>               | Compress any uncompressed content under a directory                                         |
-| -        | <kbd>Shift ⬆</kbd>         | Go to the target's parent directory                                                         |
-| -        | <kbd>Alt Shift {</kbd>     | Jump to the previous directory in the view                                                  |
-| -        | <kbd>Alt Shift }</kbd>     | Jump to the next directory in the view                                                      |
-| `rm`     | -                          | Prompt to delete the target file/directory your cursor is on                                |
-| `rename` | -                          | Rename the file/directory your cursor is on, using the passed name                          |
-| `touch`  | -                          | Make a new file under/into the file/directory your cursor is on, using the passed name      |
-| `mkdir`  | -                          | Make a new directory under/into the file/directory your cursor is on, using the passed name |
+If you want to [keybind](https://github.com/zyedidia/micro/blob/master/runtime/help/keybindings.md#rebinding-keys) any of the operations/commands, bind to the labeled API in the table below.
 
-**Note:** The <kbd>Ctrl w</kbd> keybinding is to switch which buffer your cursor is on.  
-This isn't specific to the plugin, it's just part of Micro, but many people seem to not know this.
+| Command  | Keybinding(s)              | What it does                                                                                | API for `bindings.json`               |
+| :------- | :------------------------- | :------------------------------------------------------------------------------------------ | :------------------------------------ |
+| `tree`   | -                          | Open/close the tree                                                                         | `filemanager.toggle_tree`             |
+| -        | <kbd>Tab</kbd> & MouseLeft | Open a file, or go into the directory. Goes back a dir if on `..`                           | `filemanager.try_open_at_cursor`      |
+| -        | <kbd>→</kbd>               | Uncompress a directory's content under it                                                   | `filemanager.uncompress_at_cursor`    |
+| -        | <kbd>←</kbd>               | Compress any uncompressed content under a directory                                         | `filemanager.compress_at_cursor`      |
+| -        | <kbd>Shift ⬆</kbd>         | Go to the target's parent directory                                                         | `filemanager.goto_parent_dir`         |
+| -        | <kbd>Alt Shift {</kbd>     | Jump to the previous directory in the view                                                  | `filemanager.goto_next_dir`           |
+| -        | <kbd>Alt Shift }</kbd>     | Jump to the next directory in the view                                                      | `filemanager.goto_prev_dir`           |
+| `rm`     | -                          | Prompt to delete the target file/directory your cursor is on                                | `filemanager.prompt_delete_at_cursor` |
+| `rename` | -                          | Rename the file/directory your cursor is on, using the passed name                          | `filemanager.rename_at_cursor`        |
+| `touch`  | -                          | Make a new file under/into the file/directory your cursor is on, using the passed name      | `filemanager.new_file`                |
+| `mkdir`  | -                          | Make a new directory under/into the file/directory your cursor is on, using the passed name | `filemanager.new_dir`                 |
 
-#### Rebinding Things
+#### Notes
 
-Do you want to keybind any of the operations/commands/whatever?  
-The table below specifies what you need to add to your [bindings.json in your Micro config](https://github.com/zyedidia/micro/blob/master/runtime/help/keybindings.md#rebinding-keys).
-
-| Command/Keybinding         | Used in `bindings.json`               |
-| :------------------------- | :------------------------------------ |
-| `tree`                     | `filemanager.toggle_tree`             |
-| <kbd>Tab</kbd> & MouseLeft | `filemanager.try_open_at_cursor`      |
-| <kbd>Shift ⬆</kbd>         | `filemanager.goto_parent_dir`         |
-| <kbd>Alt Shift {</kbd>     | `filemanager.goto_next_dir`           |
-| <kbd>Alt Shift }</kbd>     | `filemanager.goto_prev_dir`           |
-| `rm`                       | `filemanager.prompt_delete_at_cursor` |
-| `rename`                   | `filemanager.rename_at_cursor`        |
-| `touch`                    | `filemanager.new_file`                |
-| `mkdir`                    | `filemanager.new_dir`                 |
-
-#### Commands In-Depth
-
-Note: While these commands are Unix-like, there shouldn't be any issue on non-Unix systems like Windows, and they should still work the same.
-
-* `tree`  
-  This just opens/closes the tree. Nothing special.
-
-* `rm`  
-  It deletes the file/dir after prompting for confirmation. Nothing much to say.
-
-* `rename`, `touch`, and `mkdir`  
-  These require a name to be passed when calling. ex: `rename newnamehere`, `touch filenamehere`, `mkdir dirnamehere`.  
+* `rename`, `touch`, and `mkdir` require a name to be passed when calling.\
+  Example: `rename newnamehere`, `touch filenamehere`, `mkdir dirnamehere`.\
   If the passed name already exists in the current dir, it will cancel instead of overwriting (for safety).
+
+* The <kbd>Ctrl w</kbd> keybinding is to switch which buffer your cursor is on.\
+  This isn't specific to the plugin, it's just part of Micro, but many people seem to not know this.

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -145,18 +145,6 @@ local function get_scanlist(dir, ownership, indent_n)
 		return nil
 	end
 
-	-- The list of VCS-ignored files (if any)
-	local ignored_files = get_ignored_files(dir)
-	-- True/false if the file is an ignored file
-	local function is_ignored_file(filename)
-		for i = 1, #ignored_files do
-			if ignored_files[i] == filename then
-				return true
-			end
-		end
-		return false
-	end
-
 	-- The list of files to be returned (and eventually put in the view)
 	local results = {}
 
@@ -170,6 +158,19 @@ local function get_scanlist(dir, ownership, indent_n)
 	-- Save so we don't have to rerun GetOption a bunch
 	local show_dotfiles = GetOption("filemanager-showdotfiles")
 	local show_ignored = GetOption("filemanager-showignored")
+
+	-- The list of VCS-ignored files (if any)
+	-- Only bother gettig ignored files if we're not showing ignored
+	local ignored_files = (not show_ignored and get_ignored_files(dir) or {})
+	-- True/false if the file is an ignored file
+	local function is_ignored_file(filename)
+		for i = 1, #ignored_files do
+			if ignored_files[i] == filename then
+				return true
+			end
+		end
+		return false
+	end
 
 	-- Hold the current scan's filename in most of the loops below
 	local filename

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -425,7 +425,7 @@ local function compress_target(y, delete_y)
 				-- Reduce everything's ownership by 1 after y
 				for x = i + 1, #scanlist do
 					-- Don't touch root file/dirs
-					if scanlist[x].owner > 0 then
+					if scanlist[x].owner > y then
 						-- Minus 1 since we're just deleting y
 						scanlist[x]:decrease_owner(1)
 					end

--- a/filemanager.lua
+++ b/filemanager.lua
@@ -1208,11 +1208,18 @@ function onFindPrevious(view)
 	selectline_if_tree(view)
 end
 
+-- NOTE: This is a workaround for "cd" not having its own callback
+local precmd_dir
+
+function preCommandMode(view)
+	precmd_dir = WorkingDirectory()
+end
+
 -- Update the current dir when using "cd"
 function onCommandMode(view)
 	local new_dir = WorkingDirectory()
 	-- Only do anything if the tree is open, and they didn't cd to nothing
-	if tree_view ~= nil and new_dir ~= current_dir then
+	if tree_view ~= nil and new_dir ~= precmd_dir and new_dir ~= current_dir then
 		update_current_dir(new_dir)
 	end
 end


### PR DESCRIPTION
Unsure if you just want me to merge, tag, and push without review, so I'm posting a PR for this.

Adds two new options: `filemanager-showdotfiles` and `filemanager-showignored` (true by default)
Lets you hide dotfiles and/or vcs-ignored (only git at the moment). You can mix-and-match the options for your desired output.