### PR TITLE
Don't call ReOpen() after opening a file

### DIFF
--- a/filemanager.lua
+++ b/filemanager.lua
@@ -554,8 +554,6 @@ local function try_open_at_y(y)
 			messenger:Message("Filemanager opened ", scanlist[y].abspath)
 			-- Opens the absolute path in new vertical view
 			CurView():VSplitIndex(NewBufferFromFile(scanlist[y].abspath), 1)
-			-- Refreshes it to be visible
-			CurView().Buf:ReOpen()
 			-- Resizes all views after opening a file
 			tabs[curTab + 1]:Resize()
 		end


### PR DESCRIPTION
I'm not sure why we do this but it causes large amounts of lag with binary files - removing it doesn't seem to have any effect I can see.

Removing this mitigates https://github.com/zyedidia/micro/issues/1209.