### PR TITLE
changed default functionality to open file as new tab

### DIFF
--- a/filemanager.lua
+++ b/filemanager.lua
@@ -531,7 +531,7 @@ local function try_open_at_y(y)
 			-- Opens the absolute path in new tab
 			-- CurView():VSplitIndex(NewBufferFromFile(scanlist[y].abspath), 1)
             local nfile = scanlist[y].abspath
-            local rpath = shell.RunCommand('realpath ' .. nfile .. ' --relative-to=' .. os.Getwd())
+            local rpath = shell.RunCommand('realpath \'' .. nfile .. '\' --relative-to=\'' .. os.Getwd() .. '\'')
             toggle_tree()
 			micro.CurPane():NewTabCmd({string.sub(rpath, 1, -2)})
 			toggle_tree()


### PR DESCRIPTION
made filemanager store current data and restore when reopened
reopens filemanager on new tab
enter key also now works for opening a file or navigating working directories

Possible further improvements:
seperate tab and enter key as opening file as a split or new tab instead of doing the same thing.

Changes were originally made to version retrieved from micro's built in plugin install
seems to be based on a newer version than the one on this repo.